### PR TITLE
fix: awaiting before scope is disposed

### DIFF
--- a/src/Zeebe.Client.Accelerator/ZeebeHostedService.cs
+++ b/src/Zeebe.Client.Accelerator/ZeebeHostedService.cs
@@ -101,15 +101,15 @@ namespace Zeebe.Client.Accelerator
             workers.Clear();
         }
 
-        private Task HandleJob(IJobClient jobClient, IJob job, CancellationToken cancellationToken)
+        private async Task HandleJob(IJobClient jobClient, IJob job, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
+                throw new TaskCanceledException();
 
             using (var scope = this.serviceScopeFactory.CreateScope())
             {
                 var bootstrapJobHandler = scope.ServiceProvider.GetRequiredService<IBootstrapJobHandler>();
-                return bootstrapJobHandler.HandleJob(jobClient, job, cancellationToken);
+                await bootstrapJobHandler.HandleJob(jobClient, job, cancellationToken);
             }
         }
     }

--- a/src/Zeebe.Client.Accelerator/ZeebeHostedService.cs
+++ b/src/Zeebe.Client.Accelerator/ZeebeHostedService.cs
@@ -103,8 +103,7 @@ namespace Zeebe.Client.Accelerator
 
         private async Task HandleJob(IJobClient jobClient, IJob job, CancellationToken cancellationToken)
         {
-            if (cancellationToken.IsCancellationRequested)
-                throw new TaskCanceledException();
+            cancellationToken.ThrowIfCancellationRequested();
 
             using (var scope = this.serviceScopeFactory.CreateScope())
             {


### PR DESCRIPTION
## Issue:

When using injected services that execute asynchronous code inside `HandleJob` of a worker the service gets disposed before the `HandleJob` finishes.

## Repro:

Clone https://github.com/ng-commander/zeebe-client-csharp-accelerator/tree/disposed-issue
(Thanks to @ng-commander for providing the repro)
The repro uses the official "examples/Zeebe-Client-Accelerator-Showcase" application.

- Start the sample as you normally would
- Start the process via Swagger
- Complete the created task via the task list
- observe the `ObjectDisposedException` being thrown.

## Problem:

`HandleJob` inside `ZeebeHostedService` returns a running `Task` from within a `using` scope without `await`-ing it. This leads to the handler still running after the scope has been disposed in parallel. Any invocations on injected service that are disposable will lead to an exception.

## Fix:

Await inside `HandleJob`.
See code changes in this PR.

`if (cancellationToken.IsCancellationRequested) throw new TaskCanceledException();` was added for backwards compatibility, to throw the same exception that would be raised when the old `return Task.FromCanceled(cancellationToken)` would have been awaited.
If this is not needed the code can be shortened to `cancellationToken.ThrowIfCancellationRequested();` to make the code more succinct. This throws an `OperationCanceledExpcetion` instead of a `TaskCanceledException`.