### PR TITLE
fix: do not detect abstract class as zeebeworker

### DIFF
--- a/src/Zeebe.Client.Accelerator/JobHandlerInfoProvider.cs
+++ b/src/Zeebe.Client.Accelerator/JobHandlerInfoProvider.cs
@@ -198,6 +198,8 @@ namespace Zeebe.Client.Accelerator
 
         private static bool IsZeebeWorker(Type t)
         {
+            if (t.IsAbstract) return false;
+            
             var interfaces = t.GetInterfaces();
             return
                 interfaces.Contains(typeof(IZeebeWorker)) ||


### PR DESCRIPTION
Fixes issue #29 

When creating a abstract class for Zeebe worker class, so that the abstract class inherits from `IAsyncZeebeWorker<TInput>` or `IAsyncZeebeWorker<TInput, TResponse>` interfaces then dependency injection exception is thrown because abstract class is detected as Zeebe worker and instance instantiation fails.

### Exception
```
System.ArgumentException: Cannot instantiate implementation type '...BaseAsyncWorker`1[TInput]' for service type '...BaseAsyncWorker`1[TInput]'.
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.Populate()
   at Microsoft.Extensions.DependencyInjection.ServiceProvider..ctor(ICollection`1 serviceDescriptors, ServiceProviderOptions options)
   at Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions.BuildServiceProvider(IServiceCollection services, ServiceProviderOptions options)
   at Microsoft.Extensions.Hosting.HostApplicationBuilder.Build()
   at Microsoft.AspNetCore.Builder.WebApplicationBuilder.Build()
  at Program.<Main>$(String[] args) in Program.cs:line NN
```

### Example of the abstract class
```
public abstract class BaseAsyncWorker<TInput>, IAsyncZeebeWorker<TInput>
    where TInput : BaseVariables, new()
{
    protected abstract Task HandleJob(TInput variables, CancellationToken cancellationToken);

    public async Task HandleJob(ZeebeJob<TInput> job, CancellationToken cancellationToken)
    {
        var variables = job.getVariables();

        Exception? exception = null;
        try
        {
            await HandleJob(variables, cancellationToken);
            OnSuccess(variables);
        }
        catch (Exception e)
        {
            exception = e;
            OnError(variables, e);
            throw;
        }
        finally
        {
            await StoreStateForJob(job, exception, cancellationToken);
        }
    }
    // Base class methods omitted for brevity
}
```

### Example of the worker class inheriting from the abstract class `BaseAsyncWorker`
```
public class StartSomethingAsyncWorker : BaseAsyncWorker<MyJobVariables>
{
    protected override Task HandleJob(MyJobVariables variables, CancellationToken cancellationToken)
    {
        return apiClient.DoSomethingAsync(variables.MyUniqueId, cancellationToken);
    }
}
```

### Solution

Solution would be to detect if the type is abstract class `JobHandlerInfoProvider` and not to register the class as worker in `ZeebeHostedService` method `Task StartAsync(CancellationToken cancellationToken)`.

Proposed change in `JobHandlerInfoProvider`
```
private static bool IsZeebeWorker(Type t)
{
    if (t.IsAbstract) return false;
    
    var interfaces = t.GetInterfaces();
    return
        interfaces.Contains(typeof(IZeebeWorker)) ||
        interfaces.Contains(typeof(IAsyncZeebeWorker))
        || interfaces.Any(i => i.IsGenericType && GENERIC_HANDLER_TYPES.Contains(i.GetGenericTypeDefinition()));
}
```